### PR TITLE
Removed public keyword from init

### DIFF
--- a/Sources/ShortcutUI/SwiftUI/AlertPresenter/ActionSheet+Extension.swift
+++ b/Sources/ShortcutUI/SwiftUI/AlertPresenter/ActionSheet+Extension.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public extension ActionSheet {
-    public init(vm: AlertViewModel) {
+    init(vm: AlertViewModel) {
         self.init(title: Text(vm.title),
                   message: vm.message?.text,
                   buttons: [vm.primary.alertButton, vm.secondary?.alertButton].compactMap { $0 })

--- a/Sources/ShortcutUI/SwiftUI/AlertPresenter/Alert+Extension.swift
+++ b/Sources/ShortcutUI/SwiftUI/AlertPresenter/Alert+Extension.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public extension Alert {
-    public init(vm: AlertViewModel) {
+    init(vm: AlertViewModel) {
         if let secondary = vm.secondary {
             self.init(title: Text(vm.title),
                       message: vm.message?.text,


### PR DESCRIPTION
Removed public keyword because the extension itself is public so adding public in init is redundant.