### PR TITLE
Added helpers/ extensions for NavigationLink and View onLoad

### DIFF
--- a/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
+++ b/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
@@ -29,8 +29,8 @@ public struct NavigationLinkButton<Destination: View, Label: View>: View {
             self.label()
                 .background(
                     ScrollView { // Fixes a bug where the navigation bar may become hidden on the pushed view
-                        NavigationLink(destination: LazyDestination { self.destination() },
-                                       isActive: self.$isActive) { EmptyView() }
+                        NavigationLink(destination: LazyDestination { destination() },
+                                       isActive: $isActive) { EmptyView() }
                     }
                 )
         }

--- a/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
+++ b/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
-import Foundation
 import SwiftUI
 
 public struct NavigationLinkButton<Destination: View, Label: View>: View {
@@ -40,7 +39,9 @@ public struct NavigationLinkButton<Destination: View, Label: View>: View {
 
 // This view lets us avoid instantiating our Destination before it has been pushed.
 public struct LazyDestination<Destination: View>: View {
+    
     var destination: () -> Destination
+    
     public var body: some View {
         self.destination()
     }

--- a/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
+++ b/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
@@ -1,0 +1,47 @@
+//
+//  NavigationLink+Button.swift
+//  ShortcutUI
+//
+//  Created by Swathi on 2022-06-09.
+//  Copyright © 2021 Shortcut Scandinavia Apps AB. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+public struct NavigationLinkButton<Destination: View, Label: View>: View {
+    var action: () -> Void
+    var destination: () -> Destination
+    var label: () -> Label
+
+    @State private var isActive: Bool = false
+    
+   public init(action: @escaping () -> Void , destination: @escaping () -> Destination, label: @escaping () -> Label) {
+        self.action = action
+        self.destination = destination
+        self.label = label
+    }
+
+    public var body: some View {
+        Button(action: {
+            self.action()
+            self.isActive.toggle()
+        }) {
+            self.label()
+              .background(
+                ScrollView { // Fixes a bug where the navigation bar may become hidden on the pushed view
+                    NavigationLink(destination: LazyDestination { self.destination() },
+                                                 isActive: self.$isActive) { EmptyView() }
+                }
+              )
+        }
+    }
+}
+
+// This view lets us avoid instantiating our Destination before it has been pushed.
+public struct LazyDestination<Destination: View>: View {
+    var destination: () -> Destination
+    public var body: some View {
+        self.destination()
+    }
+}

--- a/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
+++ b/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
@@ -13,27 +13,27 @@ public struct NavigationLinkButton<Destination: View, Label: View>: View {
     var action: () -> Void
     var destination: () -> Destination
     var label: () -> Label
-
-    @State private var isActive: Bool = false
     
-   public init(action: @escaping () -> Void , destination: @escaping () -> Destination, label: @escaping () -> Label) {
+    @State private var isActive = false
+    
+    public init(action: @escaping () -> Void , destination: @escaping () -> Destination, label: @escaping () -> Label) {
         self.action = action
         self.destination = destination
         self.label = label
     }
-
+    
     public var body: some View {
         Button(action: {
             self.action()
             self.isActive.toggle()
         }) {
             self.label()
-              .background(
-                ScrollView { // Fixes a bug where the navigation bar may become hidden on the pushed view
-                    NavigationLink(destination: LazyDestination { self.destination() },
-                                                 isActive: self.$isActive) { EmptyView() }
-                }
-              )
+                .background(
+                    ScrollView { // Fixes a bug where the navigation bar may become hidden on the pushed view
+                        NavigationLink(destination: LazyDestination { self.destination() },
+                                       isActive: self.$isActive) { EmptyView() }
+                    }
+                )
         }
     }
 }

--- a/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
+++ b/Sources/ShortcutUI/SwiftUI/NavigationLink+Button.swift
@@ -3,7 +3,7 @@
 //  ShortcutUI
 //
 //  Created by Swathi on 2022-06-09.
-//  Copyright © 2021 Shortcut Scandinavia Apps AB. All rights reserved.
+//  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
 import Foundation

--- a/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
+++ b/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
@@ -20,7 +20,7 @@ struct ViewDidLoadModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.onAppear {
-            if didLoad == false {
+            if !didLoad {
                 didLoad = true
                 action?()
             }

--- a/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
+++ b/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
@@ -1,0 +1,38 @@
+//
+//  ViewDidLoadModifier.swift
+//  ShortcutUI
+//
+//  Created by Swathi on 2022-06-09.
+//  Copyright © 2021 Shortcut Scandinavia Apps AB. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct ViewDidLoadModifier: ViewModifier {
+
+    @State private var didLoad = false
+    private let action: (() -> Void)?
+
+    init(perform action: (() -> Void)? = nil) {
+        self.action = action
+    }
+
+    func body(content: Content) -> some View {
+        content.onAppear {
+            if didLoad == false {
+                didLoad = true
+                action?()
+            }
+        }
+    }
+
+}
+
+extension View {
+
+    public func onLoad(perform action: (() -> Void)? = nil) -> some View {
+        modifier(ViewDidLoadModifier(perform: action))
+    }
+
+}

--- a/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
+++ b/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
-import Foundation
 import SwiftUI
 
 struct ViewDidLoadModifier: ViewModifier {
@@ -26,13 +25,10 @@ struct ViewDidLoadModifier: ViewModifier {
             }
         }
     }
-
 }
 
 extension View {
-
     public func onLoad(perform action: (() -> Void)? = nil) -> some View {
         modifier(ViewDidLoadModifier(perform: action))
     }
-
 }

--- a/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
+++ b/Sources/ShortcutUI/SwiftUI/View+OnLoad.swift
@@ -3,7 +3,7 @@
 //  ShortcutUI
 //
 //  Created by Swathi on 2022-06-09.
-//  Copyright © 2021 Shortcut Scandinavia Apps AB. All rights reserved.
+//  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
 import Foundation


### PR DESCRIPTION
Added below extensions
1. NavigationLinkButton : Helps when you want to perform an action before pushing to a destinationView
2. View+OnLoad : Similar to viewDidLoad in swift. Has an onLoad() modifier which helps if you want to make an API call or execute code which has to happen when it is added first time in the navigationStack.