### PR TITLE
Added ActionSheet functions as unavailable for OSX

### DIFF
--- a/Sources/ShortcutUI/SwiftUI/AlertPresenter/ActionSheet+Extension.swift
+++ b/Sources/ShortcutUI/SwiftUI/AlertPresenter/ActionSheet+Extension.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+@available(OSX, unavailable)
 public extension ActionSheet {
     init(vm: AlertViewModel) {
         self.init(title: Text(vm.title),

--- a/Sources/ShortcutUI/SwiftUI/AlertPresenter/AlertPresenter.swift
+++ b/Sources/ShortcutUI/SwiftUI/AlertPresenter/AlertPresenter.swift
@@ -14,6 +14,7 @@ public protocol IAlertPresenter {
     func closeAlert()
 }
 
+@available(OSX, unavailable)
 public class AlertPresenter: ObservableObject, IAlertPresenter {
     
     @Published public var alertPresentationState: AlertPresentationState?


### PR DESCRIPTION
Since ActionSheet is not available in OSX it cannot compile at the moment.